### PR TITLE
Fix IR badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ojaynico-kotlin-native-base
 [Download](https://search.maven.org/artifact/com.github.ojaynico/ojaynico-kotlin-native-base/1.0.0/pom)
 
-![https://kotl.in/jsirsupported](https://img.shields.io/badge/Kotlin%2FJS-IR%20supported-yellow)
+[![Kotlin JS IR supported](https://img.shields.io/badge/Kotlin%2FJS-IR%20supported-yellow)](https://kotl.in/jsirsupported)
 
 Kotlin Wrapper for Native Base
 


### PR DESCRIPTION
I made a small mistake when announcing the badge on Slack, this fixes the link 🎉

